### PR TITLE
feat(github-importer): put attachments below the import details and show attachment images

### DIFF
--- a/project.py
+++ b/project.py
@@ -105,16 +105,6 @@ class Project:
         body = self._htmlentitydecode(item.description.text)
         # metadata: original author & link
 
-        try:
-            attachments = []
-            for attachment in item.attachments.attachment:
-                attachment = '\n- [' + attachment.get('name') + '](' + self.jiraBaseUrl + '/secure/attachment/' + attachment.get('id') + '/' + attachment.get('name') + ')'
-                attachments.append(attachment)
-            if len(attachments) > 0:
-                body = body + '\n\n**Attachments:**\n' + ''.join(attachments)
-        except AttributeError:
-            pass
-
         body = body + '\n\n---\n<details><summary><i>Originally reported by <a title="' + str(item.reporter) + '" href="' + self.jiraBaseUrl + '/secure/ViewProfile.jspa?name=' + item.reporter.get('username') + '">' + item.reporter.get('username') + '</a>, imported from: <a href="' + self.jiraBaseUrl + '/browse/' + item.key.text + '" target="_blank">' + item.title.text[item.title.text.index("]") + 2:len(item.title.text)] + '</a></i></summary>'
         # metadata: assignee
         body = body + '\n<i><ul>'
@@ -142,6 +132,26 @@ class Project:
         body = body + '\n<li><b>watchers</b>: ' + str(item.watches)
         body = body + '\n<li><b>imported</b>: ' + datetime.today().strftime('%Y-%m-%d')
         body = body + '\n</ul></i>\n</details>'
+
+        try:
+            attachments = []
+            image_extensions = ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.svg']
+            for attachment in item.attachments.attachment:
+                attachment_name = attachment.get('name')
+                attachment_extension = os.path.splitext(attachment_name)[1].lower()
+                attachment_txt = '[{0}]({1}/secure/attachment/{2}/{0})'.format(
+                    attachment_name,
+                    self.jiraBaseUrl,
+                    attachment.get('id')
+                )
+                if attachment_extension in image_extensions:
+                    attachment_txt = attachment_txt + '\n  > !' + attachment_txt
+
+                attachments.append('\n- ' + attachment_txt)
+            if len(attachments) > 0:
+                body = body + '\n<details><summary><i>Attachments:</i></summary>\n' + ''.join(attachments) + '\n</details>'
+        except AttributeError:
+            pass
 
         # retrieve jira components and labels as github labels
         labels = []


### PR DESCRIPTION
This PR puts attachments below the import details and shows attachment images:

Before:
> <img width="889" height="243" alt="image" src="https://github.com/user-attachments/assets/1e268c59-eced-4e8c-806f-464cdd75b59c" />

After (closed):
> <img width="891" height="183" alt="image" src="https://github.com/user-attachments/assets/86a1c357-5ff4-4af5-ae54-3c003e48bdfd" />

After (open):
> <img width="896" height="405" alt="image" src="https://github.com/user-attachments/assets/7bf22188-59f0-4cb9-9f9a-edd9e2fb7e4a" />

### Testing done

Test on my own test org and demo repo.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
