### PR TITLE
feat(jira-commenter): allow to `DONT_NOTIFY_JIRA_USERS` and to `ARCHIVE_JIRA_ISSUES` if `IS_USER_JIRA_ADMIN`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,5 @@ jira-keys-to-github-id.txt
 
 TODO.md
 issue_jira_github_mapping.json
+issue_comment_on*
+jira-comments.txt

--- a/jira-commenter.sh
+++ b/jira-commenter.sh
@@ -20,6 +20,7 @@ set -euo pipefail
 : "${JIRA_GITHUB_MAPPING_FILE:=jira-keys-to-github-id.txt}" # with each line containing <JENKINS-ISSUE-KEY>:<GITHUB-ISSUE-KEY>, ex: "INFRA-545:415"
 : "${COMMENTS_FILE:=jira-comments.txt}" # with each line containing <JENKINS-ISSUE-KEY>:<GITHUB-ISSUE-KEY>:<JIRA-COMMENT-ID>:<JIRA-COMMENT-SELF-LINK>, ex: "INFRA-545:415:457400:https://issues.jenkins.io/rest/api/2/issue/224778/comment/457400"
 : "${EXPORTED_LABEL:=issue-exported-to-github}" # label to add to issues that have been exported
+: "${JIRA_MIGRATION_ADDITIONAL_INFO:=}" # additional info to add to the comment body
 
 github_issues_link="https://github.com/${JIRA_MIGRATION_GITHUB_NAME}/${JIRA_MIGRATION_GITHUB_REPO}/issues/"
 
@@ -56,7 +57,7 @@ while IFS=':' read -ra mapping; do
     commenting_api_url="${issue_api_url}/comment"
 
     # Add export comment to Jira issue and pin it
-    body="All issues for ${JIRA_MIGRATION_JIRA_PROJECT_DESC} have been migrated to [GitHub|${github_issues_link}]\n\nHere is the link to this issue on GitHub: ${github_issues_link}${github_issue_id}\n\nTo find related issues use this search: ${github_issues_link}?q=%22${jira_issue_key}%22\n\n(_Note: this is an automated bulk comment_)"
+    body="All issues for ${JIRA_MIGRATION_JIRA_PROJECT_DESC} have been migrated to [GitHub|${github_issues_link}]\n\nHere is the link to this issue on GitHub: ${github_issues_link}${github_issue_id}\n\nTo find related issues use this search: ${github_issues_link}?q=%22${jira_issue_key}%22${JIRA_MIGRATION_ADDITIONAL_INFO}\n\n(_Note: this is an automated bulk comment_)"
     result=$(curl \
         --silent \
         -H "Content-Type: application/json" \


### PR DESCRIPTION
This PR allows (if `IS_USER_JIRA_ADMIN` is set to `true`) to not notify users on issue changes with `DONT_NOTIFY_JIRA_USERS`, and to archive issues with `ARCHIVE_JIRA_ISSUES`. (both false by default)

Refs:
- https://docs.atlassian.com/software/jira/docs/api/REST/7.2.0/#api/2/issue-editIssue about `notifyUsers`
- https://confluence.atlassian.com/adminjiraserver/archiving-an-issue-968669980.html about issue archival

### Testing done

Could not test `ARCHIVE_JIRA_ISSUES` or `DONT_NOTIFY_JIRA_USERS` on TEST project as I'm not a Jira admin.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
