### PR TITLE
feat(github-importer): add `environment` to export details

### DIFF
--- a/project.py
+++ b/project.py
@@ -104,18 +104,9 @@ class Project:
 
         body = self._htmlentitydecode(item.description.text)
         # metadata: original author & link
-
         body = body + '\n\n---\n<details><summary><i>Originally reported by <a title="' + str(item.reporter) + '" href="' + self.jiraBaseUrl + '/secure/ViewProfile.jspa?name=' + item.reporter.get('username') + '">' + item.reporter.get('username') + '</a>, imported from: <a href="' + self.jiraBaseUrl + '/browse/' + item.key.text + '" target="_blank">' + item.title.text[item.title.text.index("]") + 2:len(item.title.text)] + '</a></i></summary>'
-        # metadata: assignee
         body = body + '\n<i><ul>'
-        if item.assignee != 'Unassigned':
-            body = body + '\n<li><b>assignee</b>: <a title="' + str(item.assignee) + '" href="' + self.jiraBaseUrl + '/secure/ViewProfile.jspa?name=' + item.assignee.get('username') + '">' + item.assignee.get('username') + '</a>'
-        # include to make searching by reporter easier
-        body = body + '\n<li><b>reported by</b>: ' + item.reporter.get('username')
-        try:
-            body = body + '\n<li><b>status</b>: ' + item.status
-        except AttributeError:
-            pass
+        # metadata: environment
         try:
             environment_txt = '<b>environment</b>: <code>' + item.environment + '</code>'
             lines = str(item.environment).splitlines()
@@ -126,14 +117,27 @@ class Project:
             body = body + '\n<li>' + environment_txt
         except AttributeError:
             pass
+        # metadata: assignee
+        if item.assignee != 'Unassigned':
+            body = body + '\n<li><b>assignee</b>: <a title="' + str(item.assignee) + '" href="' + self.jiraBaseUrl + '/secure/ViewProfile.jspa?name=' + item.assignee.get('username') + '">' + item.assignee.get('username') + '</a>'
+        # include to make searching by reporter easier
+        body = body + '\n<li><b>reported by</b>: ' + item.reporter.get('username')
+        # metadata: status
+        try:
+            body = body + '\n<li><b>status</b>: ' + item.status
+        except AttributeError:
+            pass
+        # metadata: priority
         try:
             body = body + '\n<li><b>priority</b>: ' + item.priority
         except AttributeError:
             pass
+        # metadata: resolution
         try:
             body = body + '\n<li><b>resolution</b>: ' + item.resolution
         except AttributeError:
             pass
+        # metadata: resolved
         try:
             body = body + '\n<li><b>resolved</b>: ' + self._convert_to_iso(item.resolved.text)
         except AttributeError:


### PR DESCRIPTION
This PR adds `environment` to export details in GitHub issues.

For those of one line, displayed in a `<code>` block (to avoid any accidental mentions)
For those of multiple lines, displayed in a `<code>` block inside a `<details>` one.

### Testing done

<details><summary>One line environment</summary>

https://github.com/lemeurherve-org/demo/issues/89:
> <img width="580" height="329" alt="image" src="https://github.com/user-attachments/assets/a783d547-36bf-4e83-afe7-eef142047c97" />

</details>

<details><summary>Multiple lines environment</summary>

https://github.com/lemeurherve-org/demo/issues/105:
> <img width="515" height="467" alt="image" src="https://github.com/user-attachments/assets/860b7385-35bc-4a9f-bd1f-b8211a3c0e7e" />

</details>