### PR TITLE
chore(github-import): adapt jira type labels and remove redundant 'naked' component label

### DIFF
--- a/labelcolourselector.py
+++ b/labelcolourselector.py
@@ -3,7 +3,7 @@ class LabelColourSelector:
         self._project = project
 
     def get_colour(self, label):
-        elif label == 'jira-type:epic':
+        if label == 'jira-type:epic':
             return 'ddf4dd'
         elif label.startwith('jira-type:'):
             return '7bc043'

--- a/project.py
+++ b/project.py
@@ -111,7 +111,7 @@ class Project:
         labels.append(self._jira_type_mapping(item.type.text.lower()))
 
         for label in item.labels.findall('label'):
-            converted_label = convert_label(label.text.strip().lower(), self.labels_mapping, self.approved_labels)
+            converted_label = convert_label(proper_label_str(label.text), self.labels_mapping, self.approved_labels)
             if converted_label is not None:
                 labels.append(converted_label)
 

--- a/utils.py
+++ b/utils.py
@@ -33,7 +33,7 @@ def convert_label(label, labels_mappings, approved_labels):
     return None
 
 def proper_label_str(label):
-    return label.lower().replace(' ', '-').replace("'", '')
+    return label.lower().strip().replace(' ', '-').replace("'", '')
 
 def read_xml_file(file_path):
     with open(file_path) as file:


### PR DESCRIPTION
This PR removes redundant 'naked' label of components (there is already a `component:foo` one), and adapts the jira type labels, with `improvement` and `new feature` mapped to the default `enhancement` GitHub label for simplification, and the other less common types to `jira-type:<a-type>`.

#### Repartition of Jira issue types
In all ~12000 Jira `core` issues:
<details>
<img width="960" height="480" alt="image" src="https://github.com/user-attachments/assets/00ad3f0c-8802-43aa-93ec-6c4ce58c1c87" />
</details>

In all ~75000 Jira issues:
<details>
<img width="960" height="480" alt="image" src="https://github.com/user-attachments/assets/b1ba553e-1fe9-4482-a47c-180bcb4e4f63" />
</details>

### Testing done

https://github.com/lemeurherve-org/demo/issues/118
https://github.com/lemeurherve-org/demo/issues/119
https://github.com/lemeurherve-org/demo/issues/120
