### PR TITLE
chore(github-importer): move `environment` on its own line below export details

### DIFF
--- a/project.py
+++ b/project.py
@@ -160,13 +160,15 @@ class Project:
 
         # metadata: environment
         try:
-            environment_txt = '<ul><li><i>environment</i>: <code>' + item.environment + '</code></li></ul>'
-            lines = str(item.environment).splitlines()
-            # Remove empty lines
-            lines = [line for line in lines if line.replace('<br/>', '').strip() != '']
-            if len(lines) > 1:
-                environment_txt = '<details><summary><i>environment</i></summary>\n\n```\n' + '\n'.join(lines) + '\n```\n</details>'
-            body = body + '\n' + environment_txt
+            environment_value = item.environment.text.strip()
+            if environment_value:
+                environment_txt = '<ul><li><i>environment</i>: <code>' + environment_value + '</code></li></ul>'
+                lines = environment_value.splitlines()
+                # Remove empty lines
+                lines = [line for line in lines if line.replace('<br/>', '').strip() != '']
+                if len(lines) > 1:
+                    environment_txt = '<details><summary><i>environment</i></summary>\n\n```\n' + '\n'.join(lines) + '\n```\n</details>'
+                body = body + '\n' + environment_txt
         except AttributeError:
             pass
 


### PR DESCRIPTION
This PR moves `environment` on its own line below export details in GitHub issues.
It also don't mention any `environment` if empty.

Follow-up of:
- https://github.com/lemeurherve/jira-issues-importer/pull/16#discussion_r2517305263

### Testing done

No environment: https://github.com/lemeurherve-org/demo/issues/153
> <img width="490" height="109" alt="image" src="https://github.com/user-attachments/assets/c0db955d-6909-4edb-8b54-d07a3c80731f" />

Environment on one line: https://github.com/lemeurherve-org/demo/issues/154
> <img width="474" height="140" alt="image" src="https://github.com/user-attachments/assets/ddb4b49e-eddc-48a5-9871-8b73e44a2179" />

Environment on multiple lines: https://github.com/lemeurherve-org/demo/issues/155
> <img width="465" height="189" alt="image" src="https://github.com/user-attachments/assets/64c875bd-26cc-4d71-a177-b70b4ee2f4d0" />

> <img width="496" height="349" alt="image" src="https://github.com/user-attachments/assets/d8e8957d-36c6-473c-bc7d-6af3930b470d" />
