### PR TITLE
fix(github-importer): proper specific Jira markup rendering in GitHub

### DIFF
--- a/project.py
+++ b/project.py
@@ -306,7 +306,7 @@ class Project:
             for comment in item.comments.comment:
                 self._project['Issues'][-1]['comments'].append(
                     {"created_at": self._convert_to_iso(comment.get('created')),
-                     "body": '<i><a href="' + self.jiraBaseUrl + '/secure/ViewProfile.jspa?name=' + comment.get('author') + '">' + comment.get('author') + '</a>:</i>\n' + self._htmlentitydecode(comment.text)
+                     "body": '<i><a href="' + self.jiraBaseUrl + '/secure/ViewProfile.jspa?name=' + comment.get('author') + '">' + comment.get('author') + '</a>:</i>\n' + self._clean_html(comment.text)
                      })
         except AttributeError:
             pass


### PR DESCRIPTION
This PR fixes the rendering in GitHub of the problematic `{noformat}` Jira markdown. (EDIT: and other specific markup, see https://github.com/lemeurherve/jira-issues-importer/pull/22#issuecomment-3523882238)

The following Jira markdown
```
{noformat}
some code and links
{noformat}
```
generate the following HTML:
```
<div class="preformatted panel" style="border-width: 1px;"><div class="preformattedContent panelContent">
<pre>some code and links</pre>
</div></div>
```
Which GitHub try to render as HTML instead of a \<code> or \<pre> block.

### Testing done

- https://issues.jenkins.io/browse/JENKINS-75621
  ```
  {noformat}
  <li aria-expanded="false" class="children"></li> {noformat}
  ```
  On Jira:
  ><img width="446" height="180" alt="image" src="https://github.com/user-attachments/assets/4261760f-68c5-48b2-a6d3-a00e3f721f65" />
  
  Before this fix: https://github.com/lemeurherve-org/demo/issues/167
  > <img width="307" height="208" alt="image" src="https://github.com/user-attachments/assets/79dde75d-3d4f-451e-841e-a72df5ed0395" />
  - HTML interpreted, only showing a list bullet point
  
  After this fix: https://github.com/lemeurherve-org/demo/issues/169
  > <img width="413" height="177" alt="image" src="https://github.com/user-attachments/assets/54a0890c-04ae-4c74-bc4f-80e13b563a19" />
  - Proper code block rendered



- https://issues.jenkins.io/browse/JENKINS-76266

  ```
  {noformat}
  diff --git a/src/main/resources/io/jenkins/plugins/designlibrary/Select/Apple/help.html b/src/main/resources/io/jenkins/plugins/designlibrary/Select/Apple/help.html
  new file mode 100644
  index 0000000..d5df030
  --- /dev/null
  +++ b/src/main/resources/io/jenkins/plugins/designlibrary/Select/Apple/help.html
  @@ -0,0 +1,3 @@
  +<div>
  +  It's an apple. <a href="https://en.wikipedia.org/wiki/Apple" target="_blank">Learn more.</a>
  +</div>
  diff --git a/src/main/resources/scss/components/_component-sample.scss b/src/main/resources/scss/components/_component-sample.scss
  index 1c02a4e..180a0bc 100644
  --- a/src/main/resources/scss/components/_component-sample.scss
  +++ b/src/main/resources/scss/components/_component-sample.scss
  @@ -1,7 +1,6 @@
   .jdl-component-sample {
     position: relative;
     display: flex;
  -  align-items: center;
     justify-content: center;
     flex-direction: column;
     width: 100%;
   {noformat}
   ```
   On Jira:
  > <img width="1000" height="518" alt="image" src="https://github.com/user-attachments/assets/b3af1064-3986-43dc-ad00-d247628094f5" />

  Before this fix: https://github.com/lemeurherve-org/demo/issues/166
  > <img width="516" height="304" alt="image" src="https://github.com/user-attachments/assets/844a3e0f-4154-4bf5-bdf9-12d4426a2ba7" />
  - No color on `diff`
  - Link rendered
  
  After this fix: https://github.com/lemeurherve-org/demo/issues/170
  > <img width="774" height="369" alt="image" src="https://github.com/user-attachments/assets/3a4b52a5-a25c-47bf-86cb-2d55dbfcf08e" />
  - Colors on `diff`
  - Link in raw text


