### PR TITLE
fix(github-importer): link to the comment instead of the comment author

### DIFF
--- a/project.py
+++ b/project.py
@@ -306,7 +306,7 @@ class Project:
             for comment in item.comments.comment:
                 author = comment.get('author')
                 comment_link = item.link.text + '?focusedId=' + comment.get('id') + '&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-' + comment.get('id')
-                comment_body = '<i>' + author + '\'s <a href="' + comment_link + '">comment</a>:</i>\n' + self._clean_html(comment.text)
+                comment_body = '<sup><i>' + author + '\'s <a href="' + comment_link + '">comment</a>:</i></sup>\n' + self._clean_html(comment.text)
                 self._project['Issues'][-1]['comments'].append(
                     {"created_at": self._convert_to_iso(comment.get('created')),
                      "body": comment_body


### PR DESCRIPTION
This PR replaces the link on author in comments by the link to the actual comment in Jira, far more useful and avoid the issue with `JIRAUSERnnnn` comment authors:
https://github.com/lemeurherve/jira-issues-importer/blob/b7afcf4fbe6610ff37e865fe4c376a207d1df1ab/project.py#L103

Looking at all `core` issues, I found that a few hundred users have `comment.author` set to `JIRAUSERnnn` instead of their user `name` or `fullname`.

Unfortunately and unlike Jira citations in issue or comment body, only the `comment.author` is included in comments from Jira XML exports.

Ex: one of my own accounts, https://issues.jenkins.io/secure/ViewProfile.jspa?name=hlemeur, returns a `comment.author` equals to `JIRAUSER134221` in comments (but not in issues), while the `name` and full name associated with this profile are `hlemeur` & `HerveLeMeur`.

(A proper fix for those usernames could be done in a post-process step after migration, but not for this PR)


This PR also reduce the size of that comment author and link to keep the emphasis on the actual comment.

<img width="873" height="840" alt="image" src="https://github.com/user-attachments/assets/e13da25d-c64f-49e1-a94c-444f6b68ca0b" />


### Testing done

#### Before this fix
- https://github.com/lemeurherve-org/demo/issues/203#issuecomment-3523916560
> <img width="877" height="219" alt="image" src="https://github.com/user-attachments/assets/0ad451ff-9ee0-4911-87c6-66de7fa609ce" />

```html
<i><a href="https://issues.jenkins.io/secure/ViewProfile.jspa?name=JIRAUSER134221">JIRAUSER134221</a>:</i>
<p>Comment with link to Jira issue: <a href="https://issues.jenkins.io/browse/JENKINS-2440" class="external-link" rel="nofollow">https://issues.jenkins.io/browse/JENKINS-2440</a></p>

<p>cc <a href="https://issues.jenkins.io/secure/ViewProfile.jspa?name=hlemeur" class="user-hover" rel="hlemeur">HerveLeMeur</a> <a href="https://issues.jenkins.io/secure/ViewProfile.jspa?name=lemeurherve" class="user-hover" rel="lemeurherve">Hervé</a> <a href="https://issues.jenkins.io/secure/ViewProfile.jspa?name=lemeurhervecb" class="user-hover" rel="lemeurhervecb">Hervé</a> <a href="https://issues.jenkins.io/secure/ViewProfile.jspa?name=hervelemeur" class="user-hover" rel="hervelemeur">Hervé</a> (<img class="emoticon" src="https://issues.jenkins.io/images/icons/emoticons/biggrin.png" height="16" width="16" align="absmiddle" alt="" border="0"/>)</p>
```
With "Not found" error on https://issues.jenkins.io/secure/ViewProfile.jspa?name=JIRAUSER134221 link

#### After this fix
- https://github.com/lemeurherve-org/demo/issues/207#issuecomment-3524016745
> <img width="870" height="223" alt="image" src="https://github.com/user-attachments/assets/ede68eab-054d-4c8e-a982-f6995fc1d88e" />


```html
<i>JIRAUSER134221's <a href="https://issues.jenkins.io/browse/TEST-299?focusedId=457466&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-457466">comment</a>:</i>
<p>Comment with link to Jira issue: <a href="https://issues.jenkins.io/browse/JENKINS-2440" class="external-link" rel="nofollow">https://issues.jenkins.io/browse/JENKINS-2440</a></p>

<p>cc <a href="https://issues.jenkins.io/secure/ViewProfile.jspa?name=hlemeur" class="user-hover" rel="hlemeur">HerveLeMeur</a> <a href="https://issues.jenkins.io/secure/ViewProfile.jspa?name=lemeurherve" class="user-hover" rel="lemeurherve">Hervé</a> <a href="https://issues.jenkins.io/secure/ViewProfile.jspa?name=lemeurhervecb" class="user-hover" rel="lemeurhervecb">Hervé</a> <a href="https://issues.jenkins.io/secure/ViewProfile.jspa?name=hervelemeur" class="user-hover" rel="hervelemeur">Hervé</a> (<img class="emoticon" src="https://issues.jenkins.io/images/icons/emoticons/biggrin.png" height="16" width="16" align="absmiddle" alt="" border="0"/>)</p>
```

With https://issues.jenkins.io/browse/TEST-299?focusedId=457466&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-457466 link pointing directly to the focused comment on Jira.

