### PR TITLE
fix(github-importer): proper username for JIRAUSERs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,4 +100,4 @@ issue_jira_github_mapping.json
 issue_comment_on*
 jira-comments.txt
 # Store proper usernames for JIRAUSER* accounts
-mappings/jira_users_fixed.txt
+jira_fixed_usernames.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 lxml==6.0.2
 python-dateutil==2.8.0
 requests==2.32.5
-beautifulsoup4==4.12.3
-

--- a/utils.py
+++ b/utils.py
@@ -4,15 +4,21 @@ import glob
 
 
 def fetch_labels_mapping():
-    with open("labels_mapping.txt") as file:
+    with open('labels_mapping.txt') as file:
         entry = [line.split("=") for line in file.readlines()]
     return {key.strip(): value.strip() for key, value in entry}
 
 
 def fetch_allowed_labels():
-    with open("allowed_labels.txt") as file:
+    with open('allowed_labels.txt') as file:
         return [line.strip('\n') for line in file.readlines()]
 
+# Use lines from jira_fixed_usernames.txt to map JIRAUSER* to proper usernames
+# Ex of line: JIRAUSER134221:hlmeur
+def fetch_jira_fixed_usernames():
+    with open('jira_fixed_usernames.txt') as file:
+        entry = [line.split(":") for line in file.readlines()]
+    return {key.strip(): value.strip() for key, value in entry}
 
 def _map_label(label, labels_mapping):
     if label in labels_mapping:


### PR DESCRIPTION
This PR fixes the remaining issue with JIRAUSERs.

Cf #24:

> Looking at all `core` issues, I found that a few hundred users have `comment.author` set to `JIRAUSERnnn` instead of their user `name` or `fullname`.
> 
> Unfortunately and unlike Jira citations in issue or comment body, only the `comment.author` is included in comments from Jira XML exports.
> 
> Ex: one of my own accounts, https://issues.jenkins.io/secure/ViewProfile.jspa?name=hlemeur, returns a `comment.author` equals to `JIRAUSER134221` in comments (but not in issues), while the `name` and full name associated with this profile are `hlemeur` & `HerveLeMeur`.

I managed to retrieve the username for those users who reporters or assignee on issues (as XML export contains more info about them in those cases), and after some massaging, I've extracted a mapping of their JIRAUSERnnnnn id to their proper usernames.

They are stored there: https://github.com/lemeurherve-org/issues-from-jira/blob/39020d00b9512a103062963ce3b079c6164c7c63/mappings/jira_fixed_usernames.txt

(To be retrieved and stored at `./jira_fixed_usernames.txt` before executing `python3 main.py`.)

The remaining half thousand JIRAUSERs which only commented couldn't be mapped.
Their comments will stay with a JIRAUSERnnnnn author. (Unless it's possible to extract them with Jira admin rights?)

### Testing done

Comparison between before this fix and after, in the imported issue details and in the first comment:
- Before: https://github.com/lemeurherve-org/demo/issues/207#issuecomment-3524016745
> <img width="880" height="226" alt="image" src="https://github.com/user-attachments/assets/f3f6a56b-6784-4969-aaa9-1af2fbb0926f" />

- After: https://github.com/lemeurherve-org/demo/issues/218#issuecomment-3529009989
> <img width="880" height="227" alt="image" src="https://github.com/user-attachments/assets/072b9432-cbda-491b-a0b0-56f9aa67789c" />

- jira_fixed_usernames.txt empty or user not found: https://github.com/lemeurherve-org/demo/issues/226#issuecomment-3529081521
> <img width="168" height="37" alt="image" src="https://github.com/user-attachments/assets/55d76d54-20a6-4665-a194-c027cd9e24cb" />
