### PR TITLE
feat(github-importer): put raw content of original issue in import details

### DIFF
--- a/project.py
+++ b/project.py
@@ -332,7 +332,7 @@ class Project:
                 comment_link = item.link.text + '?focusedId=' + comment.get('id') + '&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-' + comment.get('id')
                 comment_body = '<sup><i>' + comment_author + '\'s <a href="' + comment_link + '">comment</a>:</i></sup>\n' + self._clean_html(comment.text)
                 if comment.text is not None:
-                    comment_body = comment_body + '\n<details><summary>Raw content of original comment</summary>\n\n<pre>\n' + item.description.text.replace('<br/>', '') + '</pre>\n</details>'
+                    comment_body = comment_body + '\n<hr><details><summary>Raw content of original comment</summary>\n\n<pre>\n' + comment.text.replace('<br/>', '') + '</pre>\n</details>'
 
                 # References for better searching
                 comment_body = comment_body + '\n\n<!-- ### Imported Jira references for easier searching -->'


### PR DESCRIPTION
This PR adds the raw content of original issue in import details for unsalvageable issues like https://issues.jenkins.io/browse/JENKINS-1918 containing the content of an XML file pasted directly in the Jira issue.

Should address the following feedback, complement #22:
> none of the many copies of JENKINS-76266 in the latest import has correct formatting, which indicates code formatting imports remain broken, making messages like https://github.com/timja-org/jenkins-gh-issues-poc-11-06-a2/issues/375#issuecomment-3499805311 useless. https://github.com/jenkinsci/jep/blob/master/jep/238/README.adoc#the-description-doesnt-render-well-in-some-cases-what-gives is just not a good answer IMO. Would it be possible to at least attach a raw wikitext output inside a details block, so if something looks off, the correct version, even if unrendered, is quickly accessible?

### Testing done

https://github.com/lemeurherve-org/demo/issues/260

<details>

> <img width="618" height="110" alt="image" src="https://github.com/user-attachments/assets/f87f8258-f2e1-4dc0-be75-0612012ff1f7" />

> <img width="606" height="324" alt="image" src="https://github.com/user-attachments/assets/fd3b4f34-b1a1-42cc-9ece-78ef5a34ed6a" />

> <img width="892" height="1560" alt="image" src="https://github.com/user-attachments/assets/eb3d2d59-d5db-4d30-89f2-3dd787f141d7" />

</details>

