### PR TITLE
feat(github-importer): add references as hidden comments for better search

### DIFF
--- a/project.py
+++ b/project.py
@@ -211,7 +211,6 @@ class Project:
         body = body + '\n<!-- [assignee=' + item.assignee.get('username') + '] -->'
         # Adding the reporter as "author" too in those references
         body = body + '\n<!-- [author=' + item.reporter.get('username') + '] -->'
-        body = body + '\n<!-- [author=' + item.reporter.text + '] -->'
 
         # Add version of the importer for future references
         body = body + '\n<!-- [importer_version=' + self.version + '] -->'


### PR DESCRIPTION
This PR adds references as hidden HTML comments for better search, with references to the reporter and assignee username and full name (in case they're differents), and a common `author` reference for both reporters and commenters for global search.

Address the following feedback:
> For example, https://github.com/jenkinsci/jep/blob/master/jep/238/README.adoc#how-do-i-find-issues-ive-reported-on-jira simply doesn't work. It has numerous false positive findings (as it seems to look for "reported", "by:" and username anywhere in the issue -- look for your own username, and the top 3 issues aren't reported by you), and wrapping it in quotes finds nothing.

### Testing done

Search with "hlemeur", too many results: https://github.com/lemeurherve-org/demo/issues?q=is%3Aissue%20state%3Aopen%20hlemeur

Search with "reporter=hlemeur", return only my tests including those refs: https://github.com/lemeurherve-org/demo/issues?q=is%3Aissue%20state%3Aopen%20reporter%3Dhlemeur

- https://github.com/lemeurherve-org/demo/issues/285:
> <img width="878" height="906" alt="image" src="https://github.com/user-attachments/assets/d7757ad4-3dba-4dea-a178-9ddf8815e69d" />
