### PR TITLE
Fix search to only consider actual repo

### DIFF
--- a/post_process_epics.sh
+++ b/post_process_epics.sh
@@ -12,7 +12,7 @@ START_FROM=${3:-0}
 # jenkins core has around 600
 SEARCH_LIMIT=1000
 
-ALL_ISSUES_WITH_EPICS=$(gh search issues --owner $OWNER --repo $REPO --limit $SEARCH_LIMIT --match comments --json number,labels -- 'Epic:')
+ALL_ISSUES_WITH_EPICS=$(gh search issues --repo "$OWNER/$REPO" --limit $SEARCH_LIMIT --match comments --json title,number,labels,url -- 'Epic:')
 ALL_ISSUE_NUMBERS=$(echo "${ALL_ISSUES_WITH_EPICS}"| jq '.[].number' | sort -g | uniq)
 
 while IFS= read -r ISSUE_CHECKING; do
@@ -29,7 +29,7 @@ while IFS= read -r ISSUE_CHECKING; do
     JIRA_ISSUE_KEY=$(echo "$COMMENT" | sed -r 's#^.*<a href="[^"]+">([^<]+)</a>.*$#\1#')
     echo "Found epic $JIRA_ISSUE_KEY"
 
-    EPIC_ISSUES_JSON=$(gh search issues --owner ${OWNER} --repo ${REPO} --match title "${JIRA_ISSUE_KEY}"  --json number,repository)
+    EPIC_ISSUES_JSON=$(gh search issues --repo "$OWNER/$REPO" --match title "${JIRA_ISSUE_KEY}"  --json number,repository)
     EPIC_ISSUE_NUMBER=$(echo "$EPIC_ISSUES_JSON" | jq '.[] | select(.repository.nameWithOwner == '\"${OWNER}/${REPO}\"').number')
     # can be empty if epic is not in core component
     if [ -n "$EPIC_ISSUE_NUMBER"  ]


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Noticed when testing remoting, it was finding issues in other repositories too.
The syntax we used must just honour the owner flag and not repo. This works fine in my testing though

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
