### PR TITLE
feat(github-importer): download mappings from hosted artifacts repo

### DIFF
--- a/project.py
+++ b/project.py
@@ -4,6 +4,7 @@ from html.entities import name2codepoint
 from dateutil.parser import parse
 from datetime import datetime
 import re
+import requests
 from urllib.parse import quote
 
 from utils import fetch_labels_mapping, fetch_allowed_labels, fetch_jira_fixed_usernames, fetch_jira_user_avatars, convert_label, proper_label_str
@@ -20,14 +21,31 @@ class Project:
 
         self.labels_mapping = fetch_labels_mapping()
         self.approved_labels = fetch_allowed_labels()
-        self.jira_fixed_usernames = fetch_jira_fixed_usernames()
-        self.jira_user_avatars = fetch_jira_user_avatars()
-        # Hosted artifacts like avatars or attachments
-        if os.getenv('JIRA_MIGRATION_HOSTED_ARTIFACT_BASE'):
-            self.hosted_artifact_base_link = os.getenv('JIRA_MIGRATION_HOSTED_ARTIFACT_BASE')
-        else:
-            # Example for artifacts hosted in a folder on GitHub
-            self.hosted_artifact_base = 'https://raw.githubusercontent.com/jenkinsci/artifacts-from-jira-issues/refs/heads/main'
+
+        self.jira_fixed_username_file = 'jira_fixed_usernames.txt'
+        self.jira_username_avatar_mapping_file = 'jira_username_avatar_mapping.txt'
+        # "org/repo" hosting artifacts like avatars, attachments and username mappings
+        # If not set, will use local files, and won't add avatar in issues or comments
+        # Example of such repo: https://github.com/lemeurherve/artifacts-from-jira-issues-example
+        if os.getenv('JIRA_MIGRATION_HOSTED_ARTIFACT_ORG_REPO'):
+            self.hosted_artifact_base = 'https://raw.githubusercontent.com/' + os.getenv('JIRA_MIGRATION_HOSTED_ARTIFACT_ORG_REPO') + '/refs/heads/main'
+
+            # Download mappings from hosted artifacts repo for further inspection post import
+            print('Downloading mappings from ' + os.getenv('JIRA_MIGRATION_HOSTED_ARTIFACT_ORG_REPO') + ' if they don\'t already exist')
+            if not os.path.exists(self.jira_fixed_username_file):
+                response = requests.get(self.hosted_artifact_base + '/mappings/' + self.jira_fixed_username_file)
+                open(self.jira_fixed_username_file, 'w').write(response.text)
+                print(self.jira_fixed_username_file + ' downloaded')
+            if not os.path.exists(self.jira_username_avatar_mapping_file):
+                response = requests.get(self.hosted_artifact_base + '/mappings/' + self.jira_username_avatar_mapping_file)
+                open(self.jira_username_avatar_mapping_file, 'w').write(response.text)
+                print(self.jira_username_avatar_mapping_file + ' downloaded')
+
+            # As avatars can only be displayed if they're hosted, load its mapping only in that case
+            self.jira_user_avatars = fetch_jira_user_avatars(self.jira_username_avatar_mapping_file)
+
+        # load proper usernames mapping from file (from local file, eventually downloaded above)
+        self.jira_fixed_usernames = fetch_jira_fixed_usernames(self.jira_fixed_username_file)
 
         self.version = '1.0.0'
 
@@ -441,11 +459,12 @@ class Project:
     # In case JIRAUSER* proper usernames are not found
     def _username_and_avatar(self, name, for_comment = ''):
         username = self._proper_jirauser_username(name)
-        if username in self.jira_user_avatars:
-            avatar_path = self.hosted_artifact_base + '/' + self.jira_user_avatars[username]
-            avatar = f'<img align="left" width="20" src="{avatar_path}" title="{username}\'s avatar" /> '
-        else:
-            avatar = ''
+        avatar = ''
+        # Retrieve avatars only if JIRA_MIGRATION_HOSTED_ARTIFACT_ORG_REPO is set
+        if self.hosted_artifact_base:
+            if username in self.jira_user_avatars:
+                avatar_path = self.hosted_artifact_base + '/' + self.jira_user_avatars[username]
+                avatar = f'<img align="left" width="20" src="{avatar_path}" title="{username}\'s avatar" /> '
         # No profile page for JIRAUSER* accounts
         if username.startswith('JIRAUSER') or for_comment:
             profile = username

--- a/utils.py
+++ b/utils.py
@@ -2,7 +2,6 @@ from lxml import objectify
 import os
 import glob
 
-
 def fetch_labels_mapping():
     with open('labels_mapping.txt') as file:
         entry = [line.split("=") for line in file.readlines()]
@@ -13,16 +12,15 @@ def fetch_allowed_labels():
     with open('allowed_labels.txt') as file:
         return [line.strip('\n') for line in file.readlines()]
 
-# Use lines from jira_fixed_usernames.txt to map JIRAUSER* to proper usernames
-# Ex: https://github.com/jenkinsci/artifacts-from-jira-issues/blob/main/mappings/jira_fixed_usernames.txt
-def fetch_jira_fixed_usernames():
-    with open('jira_fixed_usernames.txt') as file:
+# Ex of line: JIRAUSER134221:hlemeur
+def fetch_jira_fixed_usernames(filename):
+    with open(filename) as file:
         entry = [line.split(":") for line in file.readlines()]
     return {key.strip(): value.strip() for key, value in entry}
 
-# Ex: https://github.com/jenkinsci/artifacts-from-jira-issues/blob/main/mappings/jira_username_avatar_mapping.txt
-def fetch_jira_user_avatars():
-    with open('jira_username_avatar_mapping.txt') as file:
+# Ex of line: hlemeur:avatars/hlemeur.png
+def fetch_jira_user_avatars(filename):
+    with open(filename) as file:
         entry = [line.split(":") for line in file.readlines()]
     return {key.strip(): value.strip() for key, value in entry}
 
@@ -31,7 +29,6 @@ def _map_label(label, labels_mapping):
         return labels_mapping[label]
     else:
         return label
-
 
 def _is_label_approved(label, approved_labels):
     return label in approved_labels


### PR DESCRIPTION
This PR allows to download mappings from hosted artifacts repo if `JIRA_MIGRATION_HOSTED_ARTIFACT_ORG_REPO` is set and if they don't already exist locally.

The main benefit of this PR is to ensure up to date mappings for each migration import: just delete your local mappings file before starting.

> [!NOTE]
> When this env var is not set, no avatar are added in issues or comments as they need to be hosted somewhere anyway.

### Testing done

```diff
+$ export JIRA_MIGRATION_HOSTED_ARTIFACT_ORG_REPO=jenkinsci/artifacts-from-jira-issues
$ python main.py 
Start from [default "0" (beginning)]: 
Downloading mappings from jenkinsci/artifacts-from-jira-issues if they don't already exist
+jira_fixed_usernames.txt downloaded
+jira_username_avatar_mapping.txt downloaded
TEST:
  Milestones:
  Types:
                   New Feature (    1): #
  Components:
                           foo (    1): #
  Labels:
               user-experience (    1): #
Total Issues to Import: 1
Press any key to begin...
Importing milestones... https://api.github.com/repos/lemeurherve-org/demo/milestones
Importing labels... https://api.github.com/repos/lemeurherve-org/demo/labels

Importing issues...
Index =  0
Issue  TEST-299
Labels ['imported-jira-issue', 'component:foobar', 'component:foo', 'enhancement', 'resolution:unresolved', 'priority:trivial']
Imported Issue: https://github.com/lemeurherve-org/demo/issues/863
```
